### PR TITLE
feat(svelte): move to static adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"@tailwindcss/aspect-ratio": "^0.2.1"
 			},
 			"devDependencies": {
-				"@sveltejs/adapter-vercel": "next",
+				"@sveltejs/adapter-static": "next",
 				"@sveltejs/kit": "next",
 				"@typescript-eslint/eslint-plugin": "^4.19.0",
 				"@typescript-eslint/parser": "^4.19.0",
@@ -210,14 +210,11 @@
 				"node": ">= 8.0.0"
 			}
 		},
-		"node_modules/@sveltejs/adapter-vercel": {
-			"version": "1.0.0-next.28",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-vercel/-/adapter-vercel-1.0.0-next.28.tgz",
-			"integrity": "sha512-a2n4UCuTu5LhUoS5KiI5xasgvIXW8qKnSSKOnTTLYlZhpJ5VnSKWyT9hUOoVsAEGkeZw+2SYxxI3Vckw6ZhSng==",
-			"dev": true,
-			"dependencies": {
-				"esbuild": "^0.12.5"
-			}
+		"node_modules/@sveltejs/adapter-static": {
+			"version": "1.0.0-next.18",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.18.tgz",
+			"integrity": "sha512-fc6FRSkJSRi5SqYPYFWE4aGFWlF77W8EHUdmkzcQXlWTUZ75D4K4O0f/Cj6v5A3eRYxEUKzUJmkt9WJKkVi6sA==",
+			"dev": true
 		},
 		"node_modules/@sveltejs/kit": {
 			"version": "1.0.0-next.162",
@@ -3453,14 +3450,11 @@
 				"picomatch": "^2.2.2"
 			}
 		},
-		"@sveltejs/adapter-vercel": {
-			"version": "1.0.0-next.28",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-vercel/-/adapter-vercel-1.0.0-next.28.tgz",
-			"integrity": "sha512-a2n4UCuTu5LhUoS5KiI5xasgvIXW8qKnSSKOnTTLYlZhpJ5VnSKWyT9hUOoVsAEGkeZw+2SYxxI3Vckw6ZhSng==",
-			"dev": true,
-			"requires": {
-				"esbuild": "^0.12.5"
-			}
+		"@sveltejs/adapter-static": {
+			"version": "1.0.0-next.18",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.18.tgz",
+			"integrity": "sha512-fc6FRSkJSRi5SqYPYFWE4aGFWlF77W8EHUdmkzcQXlWTUZ75D4K4O0f/Cj6v5A3eRYxEUKzUJmkt9WJKkVi6sA==",
+			"dev": true
 		},
 		"@sveltejs/kit": {
 			"version": "1.0.0-next.162",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"build": "yarn run tailwind:build && yarn run build:only"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-vercel": "next",
+		"@sveltejs/adapter-static": "next",
 		"@sveltejs/kit": "next",
 		"@typescript-eslint/eslint-plugin": "^4.19.0",
 		"@typescript-eslint/parser": "^4.19.0",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,5 @@
 import preprocess from 'svelte-preprocess';
-import vercel from '@sveltejs/adapter-vercel';
+import adapter from '@sveltejs/adapter-static';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -10,7 +10,7 @@ const config = {
 	kit: {
 		// hydrate the <div id="svelte"> element in src/app.html
 		target: '#svelte',
-		adapter: vercel()
+		adapter: adapter()
 	}
 };
 


### PR DESCRIPTION
As we are not using any svelte API endpoints, there is no need to use the vercel adapter (which would configure serverless functions for us) 👍🏻 