### PR TITLE
Ensure current live event shows as open

### DIFF
--- a/src/routes/index/_events.svelte
+++ b/src/routes/index/_events.svelte
@@ -50,10 +50,11 @@
 	let nextEvent = -1;
 	$events.forEach((event, eventIndex) => {
 		const startingTime = new Date(event.timeISO).getTime();
+		const endingTime = startingTime + event.durationInMs;
 		if (startingTime < now) {
 			$events[eventIndex].hasStarted = true;
 		}
-		if (nextEvent < 0 && startingTime > now) {
+		if (nextEvent < 0 && endingTime > now) {
 			nextEvent = eventIndex;
 		}
 	});

--- a/src/styles/tailwind-output.css
+++ b/src/styles/tailwind-output.css
@@ -1192,14 +1192,6 @@ h4 {
 	padding-top: 64px;
 	padding-bottom: 64px;
 }
-.py-3\.5{
-	padding-top: 0.875rem;
-	padding-bottom: 0.875rem;
-}
-.py-3{
-	padding-top: 0.75rem;
-	padding-bottom: 0.75rem;
-}
 .py-8{
 	padding-top: 2rem;
 	padding-bottom: 2rem;
@@ -1250,6 +1242,15 @@ h4 {
 .pb-\[3rem\]{
 	padding-bottom: 3rem;
 }
+.pt-3\.5{
+	padding-top: 0.875rem;
+}
+.pb-8{
+	padding-bottom: 2rem;
+}
+.pt-3{
+	padding-top: 0.75rem;
+}
 .pb-0{
 	padding-bottom: 0px;
 }
@@ -1267,21 +1268,6 @@ h4 {
 }
 .pb-\[100px\]{
 	padding-bottom: 100px;
-}
-.pt-3\.5{
-	padding-top: 0.875rem;
-}
-.pt-3{
-	padding-top: 0.75rem;
-}
-.pb-5{
-	padding-bottom: 1.25rem;
-}
-.pb-10{
-	padding-bottom: 2.5rem;
-}
-.pb-8{
-	padding-bottom: 2rem;
 }
 .text-left{
 	text-align: left;
@@ -1380,9 +1366,6 @@ h4 {
 .opacity-100{
 	opacity: 1;
 }
-.bg-blend-darken{
-	background-blend-mode: darken;
-}
 .shadow-md{
 	--tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
 	box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -1394,14 +1377,6 @@ h4 {
 }
 .blur{
 	--tw-blur: blur(8px);
-	filter: var(--tw-filter);
-}
-.brightness-0{
-	--tw-brightness: brightness(0);
-	filter: var(--tw-filter);
-}
-.brightness-50{
-	--tw-brightness: brightness(.5);
 	filter: var(--tw-filter);
 }
 .drop-shadow{


### PR DESCRIPTION
## What does this PR do?

This ensures when an event is live, it's open in the events list rather than showing the upcoming/next event as open.

For example, during the 9/26 event:

<img width="981" alt="image" src="https://user-images.githubusercontent.com/1477010/192317327-68e5cde7-598d-469f-8a48-ce9a487bf96f.png">

## Test Plan

Tested locally during the 9/26 event:

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/1477010/192317151-724ad7a8-02be-4039-83bf-e7ca0a91fab1.png">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes